### PR TITLE
Add name to Exams links, add maths Quick Sheet links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # 🌟 awesome-epita
+
 This repository tries to regroup every learning sources made by student
 
 > Note: Do not hesitate to contribute. You can make an issue or a pull request directly. Precise the promo if you can.
@@ -6,10 +7,23 @@ This repository tries to regroup every learning sources made by student
 
 ## 🚨 Exams
 
-- http://mastercorp.epita.eu
-- https://epiportal.com
+- [Mastercorp](http://mastercorp.epita.eu)
+- [EpiPortal](https://epiportal.com)
+- [Past-Exams (EpiDocs)](https://past-exams.epidocs.eu)
 
 ## 📚 Lessons
+
+### SUP
+
+#### 2023
+
+- [S2 Maths Quick Sheet](https://kb.zoroark.guru/mS2QS) - A quick recap of (almost) everything you need to know for your S2.
+
+### SPE
+
+#### 2023
+
+- [S3 Maths Quick Sheet](https://kb.zoroark.guru/mS3QS) - A quick recap of (almost) everything you need to know for your S3
 
 ### ING1
 


### PR DESCRIPTION
I added some names to the links in the Exams section (because I found leaving just the link kind of ugly), added a link to Past-Exams, which is a more prépa-focused website made by Matiboux, and two links to some recap sheets I made for maths on my own website (https://kb.zoroark.guru, the articles are sourced from https://github.com/utybo/ZoroarkKB).